### PR TITLE
Solved experience points/levels being set to 0 on client side when teleported between dimensions/worlds

### DIFF
--- a/src/main/java/me/alexdevs/solstice/api/ServerPosition.java
+++ b/src/main/java/me/alexdevs/solstice/api/ServerPosition.java
@@ -59,6 +59,11 @@ public class ServerPosition {
                 this.yaw,
                 this.pitch
         );
+
+        //There is a bug (presumably in fabrics api) that causes experience level to be set to 0 when teleporting between dimensions/worlds
+        //Therefore this will update the experience client side as a temporary solution
+        player.addExperience(0);
+
     }
 
     public void teleport(ServerPlayerEntity player) {


### PR DESCRIPTION


There is a bug (presumably in fabrics api) that causes experience level to be set to 0 when teleporting between dimensions/worlds

Therefore this will update the experience client side as a temporary solution

P.S
*Feel free to deny and add that one line urself if u wanna.*