### PR TITLE
Fix untranslated advancements on 1.20.1

### DIFF
--- a/src/main/java/me/alexdevs/solstice/mixin/modules/styling/CustomAdvancementMixin.java
+++ b/src/main/java/me/alexdevs/solstice/mixin/modules/styling/CustomAdvancementMixin.java
@@ -1,11 +1,8 @@
 package me.alexdevs.solstice.mixin.modules.styling;
 
-import me.alexdevs.solstice.Solstice;
 import me.alexdevs.solstice.modules.styling.formatters.AdvancementFormatter;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.server.PlayerAdvancements;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
@@ -14,7 +11,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -27,21 +23,6 @@ public abstract class CustomAdvancementMixin {
     @Shadow
     private PlayerList playerList;
 
-//    @ModifyArg(method = "award", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastSystemMessage(Lnet/minecraft/network/chat/Component;Z)V"))
-//    public Component solstice$customAdvancement(Component message) {
-//        try {
-//            var translatable = (TranslatableContents) message.getContents();
-//            var key = translatable.getKey();
-//            var frameId = key.replace("chat.type.advancement.", "");
-//            var advancementContent = (TranslatableContents) ((MutableComponent) translatable.getArgument(1)).getContents();
-//            var advancementKey = ((TranslatableContents) ((MutableComponent) advancementContent.getArgument(0)).getContents()).getKey().replace(".title", "");
-//            return AdvancementFormatter.getText(player, advancementKey, frameId);
-//        } catch (Exception e) {
-//            Solstice.LOGGER.error("Exception customizing advancement message", e);
-//
-//            return message;
-//        }
-//    }
     @Inject(method = "award",at= @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastSystemMessage(Lnet/minecraft/network/chat/Component;Z)V"),locals = LocalCapture.CAPTURE_FAILSOFT)
     public void broadcastAdvancementMessage(Advancement advancement, String criterionKey, CallbackInfoReturnable<Boolean> cir){
         this.playerList.broadcastSystemMessage(AdvancementFormatter.getText(this.player,advancement),false);

--- a/src/main/java/me/alexdevs/solstice/mixin/modules/styling/CustomAdvancementMixin.java
+++ b/src/main/java/me/alexdevs/solstice/mixin/modules/styling/CustomAdvancementMixin.java
@@ -2,34 +2,52 @@ package me.alexdevs.solstice.mixin.modules.styling;
 
 import me.alexdevs.solstice.Solstice;
 import me.alexdevs.solstice.modules.styling.formatters.AdvancementFormatter;
+import net.minecraft.advancements.Advancement;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.server.PlayerAdvancements;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(PlayerAdvancements.class)
 public abstract class CustomAdvancementMixin {
     @Shadow
     private ServerPlayer player;
+    @Final
+    @Shadow
+    private PlayerList playerList;
 
-    @ModifyArg(method = "award", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastSystemMessage(Lnet/minecraft/network/chat/Component;Z)V"))
-    public Component solstice$customAdvancement(Component message) {
-        try {
-            var translatable = (TranslatableContents) message.getContents();
-            var key = translatable.getKey();
-            var frameId = key.replace("chat.type.advancement.", "");
-            var advancementContent = (TranslatableContents) ((MutableComponent) translatable.getArgument(1)).getContents();
-            var advancementKey = ((TranslatableContents) ((MutableComponent) advancementContent.getArgument(0)).getContents()).getKey().replace(".title", "");
-            return AdvancementFormatter.getText(player, advancementKey, frameId);
-        } catch (Exception e) {
-            Solstice.LOGGER.error("Exception customizing advancement message", e);
+//    @ModifyArg(method = "award", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastSystemMessage(Lnet/minecraft/network/chat/Component;Z)V"))
+//    public Component solstice$customAdvancement(Component message) {
+//        try {
+//            var translatable = (TranslatableContents) message.getContents();
+//            var key = translatable.getKey();
+//            var frameId = key.replace("chat.type.advancement.", "");
+//            var advancementContent = (TranslatableContents) ((MutableComponent) translatable.getArgument(1)).getContents();
+//            var advancementKey = ((TranslatableContents) ((MutableComponent) advancementContent.getArgument(0)).getContents()).getKey().replace(".title", "");
+//            return AdvancementFormatter.getText(player, advancementKey, frameId);
+//        } catch (Exception e) {
+//            Solstice.LOGGER.error("Exception customizing advancement message", e);
+//
+//            return message;
+//        }
+//    }
+    @Inject(method = "award",at= @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastSystemMessage(Lnet/minecraft/network/chat/Component;Z)V"),locals = LocalCapture.CAPTURE_FAILSOFT)
+    public void broadcastAdvancementMessage(Advancement advancement, String criterionKey, CallbackInfoReturnable<Boolean> cir){
+        this.playerList.broadcastSystemMessage(AdvancementFormatter.getText(this.player,advancement),false);
+    }
 
-            return message;
-        }
+    @Redirect(method="award",at= @At(value = "INVOKE", target = "Lnet/minecraft/server/players/PlayerList;broadcastSystemMessage(Lnet/minecraft/network/chat/Component;Z)V"))
+    public void broadcastSystemMessageRedirect(PlayerList instance, Component message, boolean bypassHiddenChat) { // Redirect this method into nothing.
     }
 }

--- a/src/main/java/me/alexdevs/solstice/modules/styling/formatters/AdvancementFormatter.java
+++ b/src/main/java/me/alexdevs/solstice/modules/styling/formatters/AdvancementFormatter.java
@@ -3,6 +3,7 @@ package me.alexdevs.solstice.modules.styling.formatters;
 import eu.pb4.placeholders.api.PlaceholderContext;
 import me.alexdevs.solstice.Solstice;
 import me.alexdevs.solstice.modules.styling.StylingModule;
+import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.FrameType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -10,10 +11,11 @@ import me.alexdevs.solstice.api.text.Format;
 import java.util.Map;
 
 public class AdvancementFormatter {
-    public static Component getText(ServerPlayer player, String advancementKey, String frameId) {
-        var frame = FrameType.byName(frameId);
-        var title = advancementKey + ".title";
-        var description = advancementKey + ".description";
+    public static Component getText(ServerPlayer player, Advancement advancement) {
+        var frame = advancement.getDisplay().getFrame();
+        var frameId = frame.getName();
+        var title = advancement.getDisplay().getTitle().getString();
+        var description = advancement.getDisplay().getDescription().getString();
 
         var config = Solstice.modules.getModule(StylingModule.class).getConfig();
 

--- a/src/main/java/me/alexdevs/solstice/modules/styling/formatters/AdvancementFormatter.java
+++ b/src/main/java/me/alexdevs/solstice/modules/styling/formatters/AdvancementFormatter.java
@@ -4,7 +4,6 @@ import eu.pb4.placeholders.api.PlaceholderContext;
 import me.alexdevs.solstice.Solstice;
 import me.alexdevs.solstice.modules.styling.StylingModule;
 import net.minecraft.advancements.Advancement;
-import net.minecraft.advancements.FrameType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import me.alexdevs.solstice.api.text.Format;


### PR DESCRIPTION
Some modded advancements don't follow the vanilla format.
This PR fixes this and makes all advancements properly show up in chat regardless of format