### PR TITLE
Fix repaired items have infinite durability

### DIFF
--- a/src/main/java/me/alexdevs/solstice/api/utils/ItemUtils.java
+++ b/src/main/java/me/alexdevs/solstice/api/utils/ItemUtils.java
@@ -57,7 +57,7 @@ public class ItemUtils {
     }
     public static void removeDamage(ItemStack stack) {
         //? >= 1.21.1
-        stack.remove(DataComponents.DAMAGE);
+        stack.set(DataComponents.DAMAGE, 0);
         //? < 1.21.1
         //stack.removeTagKey("Damage");
     }


### PR DESCRIPTION
Starting 1.21.1 the `/repair` command removes the component `DAMAGE`, this effectively makes the tool indestructible.
This PR sets the component's value to `0` instead, resetting the damage and maintaining the breakability.

Closes issue #66.