### PR TITLE
Fix double parsing

### DIFF
--- a/src/main/java/me/alexdevs/solstice/api/text/Format.java
+++ b/src/main/java/me/alexdevs/solstice/api/text/Format.java
@@ -42,7 +42,7 @@ public class Format {
     }
 
     public static Component parse(TextNode textNode, PlaceholderContext context, Map<String, Component> placeholders) {
-        return PARSER.parseNode(new MapPlaceholderParser(PLACEHOLDER_PATTERN, placeholders).parseNode(textNode))
+        return new MapPlaceholderParser(PLACEHOLDER_PATTERN, placeholders).parseNode(textNode)
                 //? if < 26.1
                 .toText(context);
                 //? if >= 26.1


### PR DESCRIPTION
Changes for 26.2 update and Placeholder API updates introduced a double parsing in some situations.
This was visible on MOTD and /info commands, the newlines from the files would be removed due to this double parse.